### PR TITLE
Update 2025.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,8 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
+### [2025.4.5] - 2025-08-25
+
 ### [2025.4.4] - 2025-08-24
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
-### [2025.4.6] - 2025-01-27
+### [2025.4.5] - 2025-08-25
 
 #### Added
 - **Enhanced Table Name Extraction**: Comprehensive support for various table name formats in CREATE TABLE statements
@@ -621,8 +621,6 @@ CREATE TABLE "myschema"."mytable" (id TEXT PRIMARY KEY);
 -- Mixed quoting styles
 CREATE TABLE [myschema].`mytable` (id TEXT PRIMARY KEY);
 ```
-
-### [2025.4.5] - 2025-08-25
 
 ### [2025.4.4] - 2025-08-24
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,56 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
+### [2025.4.6] - 2025-01-27
+
+#### Added
+- **Enhanced Table Name Extraction**: Comprehensive support for various table name formats in CREATE TABLE statements
+- **Schema Prefix Support**: Full support for schema-qualified table names (e.g., `my_schema.mytable`)
+- **IF NOT EXISTS Support**: Proper handling of `CREATE TABLE IF NOT EXISTS` statements
+- **Quoted Identifier Support**: Support for all major SQL identifier quoting styles:
+  - Bracketed identifiers: `[mytable]`, `[myschema].[mytable]`
+  - Backtick identifiers: `` `mytable` ``, `` `myschema`.`mytable` ``
+  - Double-quoted identifiers: `"mytable"`, `"myschema"."mytable"`
+- **Comprehensive Test Coverage**: Added 9 new test cases covering all table name extraction variants
+
+#### Enhanced
+- **SQL Parser Robustness**: Improved `_extract_create_table_components()` function to handle complex table name patterns
+- **Identifier Normalization**: New `_extract_identifier_name()` helper function for consistent handling of quoted identifiers
+- **Schema Parser Accuracy**: More reliable table name extraction from diverse SQL dialects and conventions
+
+#### Technical Improvements
+- **Token-Based Parsing**: Enhanced sqlparse token analysis for accurate table name extraction
+- **Schema Prefix Handling**: Proper parsing of dot-separated schema.table combinations
+- **Quote Style Detection**: Automatic detection and handling of different identifier quoting conventions
+- **Error Handling**: Robust error handling for malformed CREATE TABLE statements
+
+#### Supported Table Name Formats
+```sql
+-- Basic table names
+CREATE TABLE mytable (id TEXT PRIMARY KEY);
+
+-- IF NOT EXISTS variants
+CREATE TABLE IF NOT EXISTS mytable (id TEXT PRIMARY KEY);
+
+-- Schema prefixes
+CREATE TABLE my_schema.mytable (id TEXT PRIMARY KEY);
+
+-- Bracketed identifiers (SQL Server style)
+CREATE TABLE [mytable] (id TEXT PRIMARY KEY);
+CREATE TABLE [myschema].[mytable] (id TEXT PRIMARY KEY);
+
+-- Backtick identifiers (MySQL style)
+CREATE TABLE `mytable` (id TEXT PRIMARY KEY);
+CREATE TABLE `myschema`.`mytable` (id TEXT PRIMARY KEY);
+
+-- Double-quoted identifiers (PostgreSQL style)
+CREATE TABLE "mytable" (id TEXT PRIMARY KEY);
+CREATE TABLE "myschema"."mytable" (id TEXT PRIMARY KEY);
+
+-- Mixed quoting styles
+CREATE TABLE [myschema].`mytable` (id TEXT PRIMARY KEY);
+```
+
 ### [2025.4.5] - 2025-08-25
 
 ### [2025.4.4] - 2025-08-24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "splurge-sql-generator"
-version = "2025.4.4"
+version = "2025.4.5"
 description = "A Python tool for generating Python classes from SQL files"
 authors = [
     {name = "Jim Schilling"}

--- a/splurge_sql_generator/cli.py
+++ b/splurge_sql_generator/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 from splurge_sql_generator.code_generator import PythonCodeGenerator
+from splurge_sql_generator.utils import to_snake_case, find_files_by_extension
 
 
 def _find_schema_files(sql_files: list[str]) -> Optional[str]:
@@ -33,7 +34,7 @@ def _find_schema_files(sql_files: list[str]) -> Optional[str]:
     
     # Look for *.schema files in each directory
     for search_dir in search_dirs:
-        schema_files = list(search_dir.glob("*.schema"))
+        schema_files = find_files_by_extension(search_dir, ".schema")
         if schema_files:
             # Return the first schema file found
             return str(schema_files[0])
@@ -117,20 +118,7 @@ def _discover_schema_file(sql_files: list[str], schema_arg: Optional[str]) -> Op
     return schema_file
 
 
-def _to_snake_case(class_name: str) -> str:
-    """
-    Convert PascalCase class name to snake_case filename.
-    
-    Args:
-        class_name: PascalCase class name (e.g., 'UserRepository')
-        
-    Returns:
-        Snake case filename (e.g., 'user_repository')
-    """
-    import re
-    # Insert underscore before capital letters, then convert to lowercase
-    snake_case = re.sub(r'(?<!^)(?=[A-Z])', '_', class_name).lower()
-    return snake_case
+
 
 
 def _report_generated_classes(generated_classes: dict[str, str], output_dir: Optional[Path], *, dry_run: bool = False) -> None:
@@ -145,7 +133,7 @@ def _report_generated_classes(generated_classes: dict[str, str], output_dir: Opt
     if dry_run:
         # Print all generated code
         for class_name, code in generated_classes.items():
-            snake_case_name = _to_snake_case(class_name)
+            snake_case_name = to_snake_case(class_name)
             print(f"# Generated class: {class_name}: {snake_case_name}.py")
             print("=" * 50)
             print(code)
@@ -154,7 +142,7 @@ def _report_generated_classes(generated_classes: dict[str, str], output_dir: Opt
         # Report what was generated
         print(f"Generated {len(generated_classes)} Python classes:")
         for class_name in generated_classes.keys():
-            snake_case_name = _to_snake_case(class_name)
+            snake_case_name = to_snake_case(class_name)
             if output_dir:
                 print(f"    - {class_name}: {output_dir / f'{snake_case_name}.py'}")
             else:

--- a/splurge_sql_generator/code_generator.py
+++ b/splurge_sql_generator/code_generator.py
@@ -16,6 +16,7 @@ from jinja2 import Environment, FileSystemLoader
 from splurge_sql_generator.errors import SqlValidationError
 from splurge_sql_generator.schema_parser import SchemaParser
 from splurge_sql_generator.sql_parser import SqlParser
+from splurge_sql_generator.utils import to_snake_case, safe_write_file
 
 
 class PythonCodeGenerator:
@@ -100,15 +101,7 @@ class PythonCodeGenerator:
 
         # Save to file if output path provided
         if output_file_path:
-            try:
-                Path(output_file_path).write_text(
-                    python_code,
-                    encoding="utf-8",
-                )
-            except OSError as e:
-                raise OSError(
-                    f"Error writing Python file {output_file_path}: {e}"
-                ) from e
+            safe_write_file(output_file_path, python_code)
 
         return python_code
 
@@ -450,19 +443,7 @@ class PythonCodeGenerator:
         
         return "; ".join(available_columns) if available_columns else "none"
 
-    def _to_snake_case(self, class_name: str) -> str:
-        """
-        Convert PascalCase class name to snake_case filename.
-        
-        Args:
-            class_name: PascalCase class name (e.g., 'UserRepository')
-            
-        Returns:
-            Snake case filename (e.g., 'user_repository')
-        """
-        # Insert underscore before capital letters, then convert to lowercase
-        snake_case = re.sub(r'(?<!^)(?=[A-Z])', '_', class_name).lower()
-        return snake_case
+
 
     def generate_multiple_classes(
         self,
@@ -510,17 +491,9 @@ class PythonCodeGenerator:
                 # Ensure output directory exists
                 Path(output_dir).mkdir(parents=True, exist_ok=True)
                 # Convert class name to snake_case for filename
-                snake_case_name = self._to_snake_case(class_name)
+                snake_case_name = to_snake_case(class_name)
                 output_path = Path(output_dir) / f"{snake_case_name}.py"
-                try:
-                    output_path.write_text(
-                        python_code,
-                        encoding="utf-8",
-                    )
-                except OSError as e:
-                    raise OSError(
-                        f"Error writing Python file {output_path}: {e}"
-                    ) from e
+                safe_write_file(output_path, python_code)
 
         return generated_classes
 

--- a/splurge_sql_generator/sql_helper.py
+++ b/splurge_sql_generator/sql_helper.py
@@ -11,7 +11,7 @@ This module is licensed under the MIT License.
 from pathlib import Path
 import re
 import sqlparse
-from sqlparse.tokens import Comment, DML
+from sqlparse.tokens import Comment, DML, Name, Literal
 from sqlparse.sql import Statement, Token
 from splurge_sql_generator.errors import (
     SqlFileError,
@@ -424,8 +424,11 @@ def _is_identifier_token(token: Token) -> bool:
     Returns:
         True if the token is an identifier, False otherwise
     """
-    return (hasattr(token, 'ttype') and token.ttype is not None and 
-            ('Name' in str(token.ttype) or 'Literal.String.Symbol' in str(token.ttype)))
+    return (
+        hasattr(token, 'ttype') and token.ttype is not None and (
+            token.ttype in (Name, Name.Placeholder, Literal.String.Symbol)
+        )
+    )
 
 
 def _extract_identifier_name(token: Token) -> str:

--- a/splurge_sql_generator/sql_helper.py
+++ b/splurge_sql_generator/sql_helper.py
@@ -460,7 +460,7 @@ def _extract_create_table_components(tokens: list[Token], start_index: int) -> t
 
         token_value = normalize_token(name_token)
         if token_value in {"IF", "NOT", "EXISTS"}:
-            i = i + 1
+            # Continue to next token - i is already updated by _next_significant_token
             continue
 
         # Check if this is an identifier (Name, Name.Placeholder, etc.) or quoted identifier

--- a/splurge_sql_generator/sql_helper.py
+++ b/splurge_sql_generator/sql_helper.py
@@ -17,6 +17,7 @@ from splurge_sql_generator.errors import (
     SqlFileError,
     SqlValidationError,
 )
+from splurge_sql_generator.utils import clean_sql_type, normalize_string, is_empty_or_whitespace
 
 
 # Private constants for SQL statement types
@@ -31,6 +32,16 @@ _SEMICOLON: str = ";"
 _COMMA: str = ","
 _PAREN_OPEN: str = "("
 _PAREN_CLOSE: str = ")"
+
+# Private constants for SQL constraint keywords
+_CONSTRAINT_KEYWORDS: set[str] = {
+    'PRIMARY', 'FOREIGN', 'UNIQUE', 'CHECK', 'CONSTRAINT', 'INDEX',
+    'KEY', 'AUTOINCREMENT', 'DEFAULT', 'NOT', 'NULL', 'REFERENCES'
+}
+
+# Private constants for SQL type suffixes
+_TYPE_SUFFIX: str = "_TYPE"
+_TYPE_SUFFIX_LENGTH: int = 5
 
 # Public constants for statement type return values
 EXECUTE_STATEMENT: str = "execute"
@@ -50,23 +61,18 @@ def remove_sql_comments(sql_text: str) -> str:
     Returns:
         SQL string with comments removed
     """
-    if not sql_text:
-        return sql_text
+    if is_empty_or_whitespace(sql_text):
+        return ""
 
     result = sqlparse.format(sql_text, strip_comments=True)
     return str(result) if result is not None else ""
-
 
 
 def normalize_token(token: Token) -> str:
     """
     Return the uppercased, stripped value of a token.
     """
-    return (
-        str(token.value).strip().upper()
-        if hasattr(token, "value") and token.value
-        else ""
-    )
+    return normalize_string(_safe_token_value(token)).upper()
 
 
 def _next_significant_token(
@@ -79,7 +85,7 @@ def _next_significant_token(
     """
     for i in range(start, len(tokens)):
         token = tokens[i]
-        if not token.is_whitespace and token.ttype not in Comment:
+        if not _is_whitespace_or_comment(token):
             return i, token
     return None, None
 
@@ -107,7 +113,7 @@ def find_main_statement_after_with(tokens: list[Token]) -> str | None:
         token_value = normalize_token(token)
         
         # Skip whitespace and comments
-        if token.is_whitespace or token.ttype in Comment:
+        if _is_whitespace_or_comment(token):
             i += 1
             continue
             
@@ -365,7 +371,12 @@ def extract_create_table_statements(sql_content: str) -> list[tuple[str, str]]:
     Raises:
         SqlValidationError: If sqlparse fails to parse the content or encounters malformed CREATE TABLE statements
     """
-    if not sql_content or not sql_content.strip():
+    # Validate input
+    if not sql_content:
+        return []
+    
+    sql_content = str(sql_content).strip()
+    if not sql_content:
         return []
     
     # Remove comments first for cleaner parsing
@@ -392,7 +403,7 @@ def extract_create_table_statements(sql_content: str) -> list[tuple[str, str]]:
                 token = tokens[i]
                 
                 # Skip whitespace and comments
-                if token.is_whitespace or token.ttype in Comment:
+                if _is_whitespace_or_comment(token):
                     i += 1
                     continue
                 
@@ -431,6 +442,66 @@ def _is_identifier_token(token: Token) -> bool:
     )
 
 
+def _is_name_token(token: Token) -> bool:
+    """
+    Check if a token is a Name token (unquoted identifier).
+    
+    Args:
+        token: sqlparse token to check
+        
+    Returns:
+        True if the token is a Name token, False otherwise
+    """
+    return (
+        hasattr(token, 'ttype') and token.ttype is not None and 
+        token.ttype == Name
+    )
+
+
+def _is_whitespace_or_comment(token: Token) -> bool:
+    """
+    Check if a token is whitespace or a comment.
+    
+    Args:
+        token: sqlparse token to check
+        
+    Returns:
+        True if the token is whitespace or comment, False otherwise
+    """
+    return token.is_whitespace or token.ttype in Comment
+
+
+
+
+
+def _safe_token_value(token: Token) -> str:
+    """
+    Safely extract string value from a token, handling None and missing attributes.
+    
+    Args:
+        token: sqlparse token
+        
+    Returns:
+        String value of the token, or empty string if token is invalid
+    """
+    if not token or not hasattr(token, 'value'):
+        return ""
+    return normalize_string(token.value)
+
+
+def _validate_tokens_list(tokens: list[Token]) -> bool:
+    """
+    Validate that a tokens list is not None and contains valid tokens.
+    
+    Args:
+        tokens: List of tokens to validate
+        
+    Returns:
+        True if tokens list is valid, False otherwise
+    """
+    return tokens is not None and len(tokens) > 0
+
+
 def _extract_identifier_name(token: Token) -> str:
     """
     Extract the actual name from a quoted or unquoted identifier token.
@@ -441,7 +512,7 @@ def _extract_identifier_name(token: Token) -> str:
     Returns:
         The actual identifier name without quotes
     """
-    value = str(token.value).strip()
+    value = _safe_token_value(token).strip()
     
     # Handle different quoting styles
     if value.startswith('[') and value.endswith(']'):
@@ -465,6 +536,10 @@ def _extract_create_table_components(tokens: list[Token], start_index: int) -> t
     Returns:
         Tuple of (table_name, table_body) or (None, None) if not found
     """
+    # Validate input parameters
+    if not _validate_tokens_list(tokens) or start_index < 0 or start_index >= len(tokens):
+        return None, None
+    
     table_name = None
     table_body = None
     
@@ -530,9 +605,10 @@ def _extract_create_table_components(tokens: list[Token], start_index: int) -> t
     
     for j in range(body_start, len(tokens)):
         token = tokens[j]
-        if str(token.value) == '(':
+        token_value = _safe_token_value(token)
+        if token_value == '(':
             paren_count += 1
-        elif str(token.value) == ')':
+        elif token_value == ')':
             paren_count -= 1
             if paren_count == 0:
                 body_end = j
@@ -572,7 +648,12 @@ def parse_table_columns(table_body: str) -> dict[str, str]:
         >>> parse_table_columns("user_id INTEGER, email VARCHAR(255) UNIQUE")
         {'user_id': 'INTEGER', 'email': 'VARCHAR'}
     """
-    if not table_body or not table_body.strip():
+    # Validate input
+    if is_empty_or_whitespace(table_body):
+        raise SqlValidationError("Table body cannot be None or empty")
+    
+    table_body = normalize_string(table_body)
+    if is_empty_or_whitespace(table_body):
         raise SqlValidationError("No valid column definitions found in table body")
     
     columns: dict[str, str] = {}
@@ -619,7 +700,7 @@ def _split_by_top_level_commas(tokens: list[Token]) -> list[list[Token]]:
     paren_count = 0
     
     for token in tokens:
-        token_value = str(token.value)
+        token_value = _safe_token_value(token)
         
         if token_value == '(':
             paren_count += 1
@@ -652,50 +733,42 @@ def _extract_column_name_and_type(tokens: list[Token]) -> tuple[str, str]:
     if not tokens:
         return None, None
     
-    # Skip constraint keywords at the beginning
-    constraint_keywords = {
-        'PRIMARY', 'FOREIGN', 'UNIQUE', 'CHECK', 'CONSTRAINT', 'INDEX',
-        'KEY', 'AUTOINCREMENT', 'DEFAULT', 'NOT', 'NULL', 'REFERENCES'
-    }
-    
     # Find the first identifier (column name)
     column_name = None
     type_start_idx = None
     
     for i, token in enumerate(tokens):
-        if token.is_whitespace or token.ttype in Comment:
+        if _is_whitespace_or_comment(token):
             continue
         
         token_value = normalize_token(token)
         
-        # Skip constraint keywords
-        if token_value in constraint_keywords:
+        # Skip constraint keywords at the beginning (these indicate table-level constraints)
+        if token_value in _CONSTRAINT_KEYWORDS:
             return None, None
         
         # Check if this is an identifier (column name)
-        if hasattr(token, 'ttype') and token.ttype is not None:
-            if 'Name' in str(token.ttype):
-                column_name = str(token.value).strip()
-                type_start_idx = i + 1
-                break
+        if _is_name_token(token):
+            column_name = str(token.value).strip()
+            type_start_idx = i + 1
+            break
     
     if not column_name or type_start_idx is None:
         return None, None
     
     # Extract SQL type (next identifier after column name)
-    sql_type = None
     type_tokens = []
     
     for i in range(type_start_idx, len(tokens)):
         token = tokens[i]
         
-        if token.is_whitespace or token.ttype in Comment:
+        if _is_whitespace_or_comment(token):
             continue
         
         token_value = str(token.value)
         
         # Stop at constraint keywords
-        if normalize_token(token) in constraint_keywords:
+        if normalize_token(token) in _CONSTRAINT_KEYWORDS:
             break
         
         # Collect type tokens
@@ -704,16 +777,17 @@ def _extract_column_name_and_type(tokens: list[Token]) -> tuple[str, str]:
     if type_tokens:
         # Join type tokens and clean up
         sql_type = ''.join(type_tokens).strip()
-        # Remove size specifications like (255), (10,2)
-        sql_type = re.sub(r'\(\s*\d+(?:\s*,\s*\d+)?\s*\)', '', sql_type).strip()
+        # First clean size specifications
+        sql_type = clean_sql_type(sql_type)
         # Remove any remaining constraint keywords that might have been included
-        for keyword in constraint_keywords:
+        for keyword in _CONSTRAINT_KEYWORDS:
             sql_type = sql_type.replace(keyword, '').strip()
         # Legacy behavior: strip _TYPE suffix for unknown types
-        if sql_type.endswith('_TYPE'):
-            sql_type = sql_type[:-5]  # Remove '_TYPE' suffix
+        if sql_type.endswith(_TYPE_SUFFIX):
+            sql_type = sql_type[:-_TYPE_SUFFIX_LENGTH]
+        return column_name, sql_type
     
-    return column_name, sql_type
+    return column_name, None
 
 
 def extract_table_names(sql_query: str) -> list[str]:

--- a/splurge_sql_generator/sql_helper.py
+++ b/splurge_sql_generator/sql_helper.py
@@ -481,6 +481,7 @@ def _extract_create_table_components(tokens: list[Token], start_index: int) -> t
                 table_name = _extract_identifier_name(name_token)
             break
         
+        # If we get here, the token is not an identifier, so we can't find a table name
         return None, None
 
     if not table_name:

--- a/splurge_sql_generator/utils.py
+++ b/splurge_sql_generator/utils.py
@@ -1,0 +1,264 @@
+"""
+Utility functions shared across the splurge_sql_generator package.
+
+This module contains common helper functions used by multiple modules
+to reduce code duplication and improve maintainability.
+
+Copyright (c) 2025, Jim Schilling
+
+This module is licensed under the MIT License.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+# Private constants for common operations
+_SNAKE_CASE_PATTERN = re.compile(r'(?<!^)(?=[A-Z])')
+_SQL_SIZE_PATTERN = re.compile(r'\(\s*\d+(?:\s*,\s*\d+)?\s*\)')
+
+# Private constants for file extensions
+_SQL_EXTENSION = ".sql"
+_SCHEMA_EXTENSION = ".schema"
+_YAML_EXTENSION = ".yaml"
+
+# Private constants for encoding
+_DEFAULT_ENCODING = "utf-8"
+
+
+def to_snake_case(class_name: str) -> str:
+    """
+    Convert PascalCase class name to snake_case filename.
+    
+    Args:
+        class_name: PascalCase class name (e.g., 'UserRepository')
+        
+    Returns:
+        Snake case filename (e.g., 'user_repository')
+        
+    Examples:
+        >>> to_snake_case('UserRepository')
+        'user_repository'
+        >>> to_snake_case('ProductService')
+        'product_service'
+        >>> to_snake_case('API')
+        'api'
+    """
+    if not class_name:
+        return class_name
+    
+    # Insert underscore before capital letters, then convert to lowercase
+    snake_case = _SNAKE_CASE_PATTERN.sub('_', class_name).lower()
+    return snake_case
+
+
+def clean_sql_type(sql_type: str) -> str:
+    """
+    Clean and normalize SQL type by removing size specifications.
+    
+    Args:
+        sql_type: Raw SQL type string
+        
+    Returns:
+        Cleaned SQL type string
+        
+    Examples:
+        >>> clean_sql_type('VARCHAR(255)')
+        'VARCHAR'
+        >>> clean_sql_type('DECIMAL(10,2)')
+        'DECIMAL'
+        >>> clean_sql_type('INTEGER')
+        'INTEGER'
+    """
+    if not sql_type:
+        return sql_type
+    
+    # Remove size specifications like (255), (10,2)
+    cleaned = _SQL_SIZE_PATTERN.sub('', sql_type).strip()
+    return cleaned
+
+
+def validate_file_path(file_path: str | Path, *, 
+                      must_exist: bool = True,
+                      extension: str | None = None) -> Path:
+    """
+    Validate and normalize a file path.
+    
+    Args:
+        file_path: File path to validate
+        must_exist: Whether the file must exist (default: True)
+        extension: Expected file extension (e.g., '.sql', '.schema')
+        
+    Returns:
+        Normalized Path object
+        
+    Raises:
+        FileNotFoundError: If must_exist is True and file doesn't exist
+        ValueError: If extension doesn't match expected extension
+    """
+    path = Path(file_path)
+    
+    if must_exist and not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    
+    if extension and path.suffix.lower() != extension.lower():
+        raise ValueError(f"File must have {extension} extension: {path}")
+    
+    return path
+
+
+def safe_read_file(file_path: str | Path, *, encoding: str = _DEFAULT_ENCODING) -> str:
+    """
+    Safely read a file with proper error handling.
+    
+    Args:
+        file_path: Path to the file to read
+        encoding: File encoding (default: utf-8)
+        
+    Returns:
+        File content as string
+        
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        PermissionError: If file cannot be read due to permissions
+        UnicodeDecodeError: If file contains invalid encoding
+        OSError: For other I/O errors
+    """
+    path = Path(file_path)
+    
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    
+    try:
+        return path.read_text(encoding=encoding)
+    except PermissionError as e:
+        raise PermissionError(f"Permission denied reading file '{path}': {e}") from e
+    except UnicodeDecodeError as e:
+        raise UnicodeDecodeError(
+            f"Invalid {encoding} encoding in file '{path}': {e}",
+            e.object, e.start, e.end
+        ) from e
+    except OSError as e:
+        raise OSError(f"Error reading file '{path}': {e}") from e
+
+
+def safe_write_file(file_path: str | Path, content: str, *, 
+                   encoding: str = _DEFAULT_ENCODING,
+                   create_parents: bool = True) -> None:
+    """
+    Safely write content to a file with proper error handling.
+    
+    Args:
+        file_path: Path to the file to write
+        content: Content to write to the file
+        encoding: File encoding (default: utf-8)
+        create_parents: Whether to create parent directories (default: True)
+        
+    Raises:
+        PermissionError: If file cannot be written due to permissions
+        OSError: For other I/O errors
+    """
+    path = Path(file_path)
+    
+    if create_parents:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        path.write_text(content, encoding=encoding)
+    except PermissionError as e:
+        raise PermissionError(f"Permission denied writing file '{path}': {e}") from e
+    except OSError as e:
+        raise OSError(f"Error writing file '{path}': {e}") from e
+
+
+def find_files_by_extension(directory: str | Path, extension: str) -> list[Path]:
+    """
+    Find all files with a specific extension in a directory.
+    
+    Args:
+        directory: Directory to search in
+        extension: File extension to search for (e.g., '.sql', '.schema')
+        
+    Returns:
+        List of Path objects for matching files
+    """
+    path = Path(directory)
+    if not path.exists():
+        return []
+    
+    return list(path.glob(f"*{extension}"))
+
+
+def validate_python_identifier(name: str, *, 
+                             context: str = "identifier",
+                             file_path: str | Path | None = None) -> None:
+    """
+    Validate that a string is a valid Python identifier.
+    
+    Args:
+        name: String to validate
+        context: Context for error messages (e.g., "class name", "method name")
+        file_path: Optional file path for error context
+        
+    Raises:
+        ValueError: If name is not a valid Python identifier
+    """
+    import keyword
+    
+    if not name:
+        file_context = f" in {file_path}" if file_path else ""
+        raise ValueError(f"{context.capitalize()} cannot be empty{file_context}")
+    
+    if not name.isidentifier():
+        file_context = f" in {file_path}" if file_path else ""
+        raise ValueError(f"{context.capitalize()} must be a valid Python identifier{file_context}: {name}")
+    
+    if keyword.iskeyword(name):
+        file_context = f" in {file_path}" if file_path else ""
+        raise ValueError(f"{context.capitalize()} cannot be a reserved keyword{file_context}: {name}")
+
+
+def format_error_context(file_path: str | Path | None = None) -> str:
+    """
+    Format file path for error context messages.
+    
+    Args:
+        file_path: Optional file path
+        
+    Returns:
+        Formatted error context string
+    """
+    if file_path is None:
+        return ""
+    return f" in {file_path}"
+
+
+def normalize_string(value: Any) -> str:
+    """
+    Safely convert any value to a normalized string.
+    
+    Args:
+        value: Value to convert
+        
+    Returns:
+        Normalized string
+    """
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def is_empty_or_whitespace(value: Any) -> bool:
+    """
+    Check if a value is empty or contains only whitespace.
+    
+    Args:
+        value: Value to check
+        
+    Returns:
+        True if value is empty or whitespace-only
+    """
+    if value is None:
+        return True
+    return not str(value).strip()

--- a/tests/test_remove_sql_comments.py
+++ b/tests/test_remove_sql_comments.py
@@ -20,7 +20,7 @@ class TestRemoveSqlComments:
     def test_none_string(self):
         """Test removing comments from None string."""
         result = remove_sql_comments(None)
-        assert result is None
+        assert result == ""
 
     def test_no_comments(self):
         """Test SQL with no comments."""

--- a/tests/test_schema_parser.py
+++ b/tests/test_schema_parser.py
@@ -123,6 +123,150 @@ Default: Any
         self.assertEqual(schema["created_at"], "TIMESTAMP")
         self.assertEqual(schema["updated_at"], "TIMESTAMP")
 
+    def test_parse_create_table_if_not_exists(self):
+        """Test parsing CREATE TABLE IF NOT EXISTS statements extracts table name."""
+        sql = """
+        CREATE TABLE IF NOT EXISTS mytable (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_schema_prefix(self):
+        """Test parsing CREATE TABLE statements with schema prefix extracts table name."""
+        sql = """
+        CREATE TABLE my_schema.mytable (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_bracketed_schema_prefix(self):
+        """Test parsing CREATE TABLE statements with bracketed schema prefix extracts table name."""
+        sql = """
+        CREATE TABLE [myschema].[mytable] (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_bracketed_table_name(self):
+        """Test parsing CREATE TABLE statements with bracketed table name extracts table name."""
+        sql = """
+        CREATE TABLE [mytable] (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_backtick_table_name(self):
+        """Test parsing CREATE TABLE statements with backtick-quoted table name extracts table name."""
+        sql = """
+        CREATE TABLE `mytable` (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_backtick_schema_prefix(self):
+        """Test parsing CREATE TABLE statements with backtick-quoted schema prefix extracts table name."""
+        sql = """
+        CREATE TABLE `myschema`.`mytable` (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_quoted_table_name(self):
+        """Test parsing CREATE TABLE statements with double-quoted table name extracts table name."""
+        sql = """
+        CREATE TABLE "mytable" (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_quoted_schema_prefix(self):
+        """Test parsing CREATE TABLE statements with double-quoted schema prefix extracts table name."""
+        sql = """
+        CREATE TABLE "myschema"."mytable" (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
+    def test_parse_create_table_with_mixed_quoting(self):
+        """Test parsing CREATE TABLE statements with mixed quoting styles extracts table name."""
+        sql = """
+        CREATE TABLE [myschema].`mytable` (
+            id TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+
+        tables = self.parser._parse_schema_content(sql)
+
+        self.assertIn("mytable", tables)
+        schema = tables["mytable"]
+        self.assertEqual(schema["id"], "TEXT")
+        self.assertEqual(schema["value"], "TEXT")
+
     def test_parse_create_table_with_complex_types(self):
         """Test parsing CREATE TABLE with complex SQL types."""
         sql = """

--- a/tests/test_sql_helper.py
+++ b/tests/test_sql_helper.py
@@ -37,7 +37,7 @@ class TestSqlHelperPublicAPI:
         """Test remove_sql_comments with edge cases."""
         # Empty and None inputs
         assert remove_sql_comments("") == ""
-        assert remove_sql_comments(None) == None  # Function returns None for None input
+        assert remove_sql_comments(None) == ""  # Function returns empty string for None input
         
         # Whitespace only - sqlparse strips whitespace
         assert remove_sql_comments("   \n\t  ") == ""

--- a/tests/test_sql_parser.py
+++ b/tests/test_sql_parser.py
@@ -396,7 +396,7 @@ SELECT * FROM users WHERE id = :user_id;
         """
         with self.assertRaises(SqlValidationError) as cm:
             self.parser.parse_string(sql)
-        self.assertIn("Class name must be a valid Python identifier", str(cm.exception))
+        self.assertIn("Class name cannot be a reserved keyword", str(cm.exception))
 
     def test_parse_string_class_comment_formats(self):
         """Test parse_string accepts both '#Class' and '# Class' formats."""


### PR DESCRIPTION
This pull request adds comprehensive support for extracting table names from `CREATE TABLE` statements across a wide variety of SQL dialects and quoting conventions. The main focus is on enhancing the parser's robustness and accuracy, especially for schema-qualified and quoted table names, and ensuring this is covered by thorough testing.

**SQL Table Name Extraction Enhancements**

* Added support for schema-qualified table names (e.g., `my_schema.mytable`) and proper parsing of dot-separated schema.table combinations in `CREATE TABLE` statements.
* Implemented robust handling of quoted identifiers, including bracketed (`[mytable]`), backtick-quoted (`` `mytable` ``), and double-quoted (`"mytable"`) names, as well as mixed quoting styles.
* Improved detection and handling of the `IF NOT EXISTS` clause in `CREATE TABLE` statements, ensuring table names are correctly extracted regardless of its presence.

**Testing and Documentation Improvements**

* Added 9 new test cases in `tests/test_schema_parser.py` to cover all major table name extraction variants, including schema prefixes and various quoting styles.
* Updated the changelog in `README.md` to document the new features, supported formats, and technical improvements for this release.

**Technical and Version Updates**

* Bumped the package version to `2025.4.5` in `pyproject.toml`.